### PR TITLE
补充 cxmnbt 的贡献者映射

### DIFF
--- a/docs/.vitepress/helpers/contributors.ts
+++ b/docs/.vitepress/helpers/contributors.ts
@@ -39,6 +39,10 @@ const customAuthors: CustomAuthor[] = [
     id: 273101381,
     mapByNameAliases: ['dfghj345'],
   },
+  {
+    id: 92634605,
+    mapByNameAliases: ['cxmnbt'],
+  },
 ];
 
 const authors: Author[] = [


### PR DESCRIPTION
## 问题

`#139`、`#140`、`#141` 中的若干提交使用了 `cxmnbt <cxmnbt@example.com>` 作为作者信息。该邮箱为占位地址，未关联任何 GitHub 账号，因此 `@nolebase/vitepress-plugin-git-changelog` 无法把这些提交匹配到对应账号，受影响页面底部的「贡献者」栏只会显示裸名字，没有头像和主页链接。

受影响的页面：

- `docs/contact/unofficial.md`
- `docs/organizations/associations/zhaijidi.md`
- `docs/life/digital/network.md`
- `docs/life/dormitory/electricity.md`

## 改动

在 `docs/.vitepress/helpers/contributors.ts` 的 `customAuthors` 中补一条映射，指向 GitHub 账号 `asidjwiaijd`（id `92634605`，显示名 LitterCarrot）。

`getAuthorDetail()` 会据此拉取真实姓名、头像和主页，`getNameAlias()` 会自动生成别名变体，并补上 `92634605+asidjwiaijd@users.noreply.github.com` 作为邮箱别名。因此这一条同时覆盖：

- 已合并的旧提交 —— 通过名字别名 `cxmnbt` 匹配
- 今后的提交 —— 通过 noreply 邮箱匹配（本地 git 身份已更正）

## 说明

提交历史本身未作改动。相关提交已合并进 `dev`，改写作者信息需要强推共享分支，会影响其他贡献者，因此改用映射表解决——这也正是 `customAuthors` 的设计用途（见该文件注释：「co-author 或非 GitHub 贡献者的自定义作者列表」）。